### PR TITLE
PMML SpringBoot/SCSt 2.x compatibility

### DIFF
--- a/pmml-app-dependencies/pom.xml
+++ b/pmml-app-dependencies/pom.xml
@@ -1,45 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.springframework.cloud.stream.app</groupId>
-    <artifactId>pmml-app-dependencies</artifactId>
-    <version>2.0.0.BUILD-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <name>pmml-app-dependencies</name>
-    <description>Spring Cloud Stream pmml App Dependencies</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.cloud.stream.app</groupId>
+	<artifactId>pmml-app-dependencies</artifactId>
+	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>pmml-app-dependencies</name>
+	<description>Spring Cloud Stream pmml App Dependencies</description>
 
-    <parent>
-	<artifactId>spring-cloud-dependencies-parent</artifactId>
-        <groupId>org.springframework.cloud</groupId>
-        <version>2.0.0.BUILD-SNAPSHOT</version>
-        <relativePath />
-    </parent>
+	<parent>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<relativePath/>
+	</parent>
 
-    <properties>
-        <pmml.version>1.2.6</pmml.version>
-    </properties>
+	<properties>
+		<pmml.version>1.4.0</pmml.version>
+	</properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-processor-pmml</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jpmml</groupId>
-                <artifactId>pmml-evaluator</artifactId>
-                <version>${pmml.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>pmml-app-starters-test-support</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-<profiles>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-processor-pmml</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jpmml</groupId>
+				<artifactId>pmml-evaluator</artifactId>
+				<version>${pmml.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>pmml-app-starters-test-support</artifactId>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/pmml-app-starters-test-support/pom.xml
+++ b/pmml-app-starters-test-support/pom.xml
@@ -14,6 +14,10 @@
             <groupId>org.springframework.cloud.stream.app</groupId>
             <artifactId>app-starters-test-support</artifactId>
         </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud.stream.app</groupId>
+			<artifactId>app-starters-test-support</artifactId>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pmml-app-starters-build</artifactId>
 	<version>2.0.0.BUILD-SNAPSHOT</version>
@@ -29,7 +30,7 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-<profiles>
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-stream-processor-pmml/README.adoc
+++ b/spring-cloud-starter-stream-processor-pmml/README.adoc
@@ -28,11 +28,11 @@ N/A
 The **$$pmml$$** $$processor$$ has the following options:
 
 //tag::configuration-properties[]
-$$pmml.inputs$$:: $$How to compute model active fields from input message properties as modelField->SpEL.$$ *($$java.util.Map<java.lang.String,org.springframework.expression.Expression>$$, default: `$$<none>$$`)*
+$$pmml.inputs$$:: $$How to compute model active fields from input message properties as modelField->SpEL.$$ *($$Map<String, Expression>$$, default: `$$<none>$$`)*
 $$pmml.model-location$$:: $$The location of the PMML model file.$$ *($$Resource$$, default: `$$<none>$$`)*
 $$pmml.model-name$$:: $$If the model file contains multiple models, the name of the one to use.$$ *($$String$$, default: `$$<none>$$`)*
 $$pmml.model-name-expression$$:: $$If the model file contains multiple models, the name of the one to use, as a SpEL expression.$$ *($$Expression$$, default: `$$<none>$$`)*
-$$pmml.outputs$$:: $$How to emit evaluation results in the output message as msgProperty->SpEL.$$ *($$java.util.Map<java.lang.String,org.springframework.expression.Expression>$$, default: `$$<none>$$`)*
+$$pmml.outputs$$:: $$How to emit evaluation results in the output message as msgProperty->SpEL.$$ *($$Map<String, Expression>$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 == Build

--- a/spring-cloud-starter-stream-processor-pmml/pom.xml
+++ b/spring-cloud-starter-stream-processor-pmml/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-starter-stream-processor-pmml</artifactId>
@@ -21,6 +22,15 @@
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>pmml-app-starters-test-support</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud.stream.app</groupId>
+			<artifactId>app-starters-postprocessor-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-support</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -44,7 +54,9 @@
 					</bom>
 					<generatedApps>
 						<pmml-processor>
-							<extraTestConfigClass>org.springframework.cloud.stream.app.test.pmml.PmmlProcessorTestConfiguration.class</extraTestConfigClass>
+							<extraTestConfigClass>
+								org.springframework.cloud.stream.app.test.pmml.PmmlProcessorTestConfiguration.class
+							</extraTestConfigClass>
 						</pmml-processor>
 					</generatedApps>
 				</configuration>


### PR DESCRIPTION
Resolves #3
PartOf https://github.com/spring-cloud-stream-app-starters/app-starters-release/issues/134

- Update to Spring Boot 2.0, Spring Cloud 2.x and Spring Cloud Stream 2.0
- Update PMML to latest 1.4.0
- Fix content-type handling
- Add tests with string/json input and default, originContentType and contentType headers.